### PR TITLE
Add Native Federation bootstrap setup for Angular builder app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
 
 https://icons.getbootstrap.com/
+
+## Native Federation
+
+This template is prepared for Native Federation with Angular builder applications.
+
+- Federation runtime initialization is in `src/main.ts`.
+- Angular bootstrap has been moved to `src/bootstrap.ts`.
+- Federation defaults are in `federation.config.js`.
+
+After installing dependencies, you can run:
+
+- `npm run start:mf` to start the app in development mode.
+- `npm run build:mf` to build with production configuration.

--- a/federation.config.js
+++ b/federation.config.js
@@ -1,0 +1,14 @@
+const { withNativeFederation, shareAll } = require('@angular-architects/native-federation/config');
+
+module.exports = withNativeFederation({
+  name: 'angular_bootstrap_firebase_template',
+  exposes: {},
+  shared: {
+    ...shareAll({
+      singleton: true,
+      strictVersion: true,
+      requiredVersion: 'auto',
+    }),
+  },
+  skip: ['rxjs/ajax', 'rxjs/fetch', 'rxjs/testing', 'rxjs/webSocket'],
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "serve": "ng serve",
+    "start:mf": "ng serve --configuration development",
+    "build:mf": "ng build --configuration production"
   },
   "private": true,
   "dependencies": {
@@ -21,7 +24,9 @@
     "bootstrap": "^5.3.3",
     "rxjs": "~7.8.1",
     "tslib": "^2.8.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "@angular-architects/native-federation": "^20.0.0",
+    "es-module-shims": "^1.10.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^20.0.0",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,13 @@
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,6 @@
-import { enableProdMode } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { initFederation } from '@angular-architects/native-federation';
 
-import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
-
-if (environment.production) {
-  enableProdMode();
-}
-
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+initFederation()
+  .catch((err) => console.error(err))
+  .then(() => import('./bootstrap'))
+  .catch((err) => console.error(err));


### PR DESCRIPTION
### Motivation
- Enable Native Module Federation for builder-style Angular applications so this template can act as a host or a federated builder app.
- Provide a minimal, opinionated runtime and build wiring so downstream projects can opt into federation with little manual setup.

### Description
- Replace the direct bootstrap in `src/main.ts` with a federation-aware startup that calls `initFederation()` and dynamically imports the bootstrap module via `import('./bootstrap')`.
- Add `src/bootstrap.ts` which contains the original Angular bootstrap logic including the production mode guard and `platformBrowserDynamic().bootstrapModule(AppModule)`.
- Add `federation.config.js` with `withNativeFederation` and `shareAll(...)` to expose a baseline shared-deps configuration and skip known RxJS entry points.
- Update `package.json` to add `@angular-architects/native-federation` and `es-module-shims` to `dependencies` and to add helper npm scripts `start:mf` and `build:mf`, and document the setup in `README.md` with usage hints.

### Testing
- Attempted `npm install` in this environment but it failed due to registry/security restrictions and returned `403`/package resolution errors so dependencies were not installed.
- Attempted `npm run build` which failed because `ng` was unavailable in the environment since dependencies could not be installed, so no build or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12dc8d5170832f986a5c65406a3a8b)